### PR TITLE
Absord-cp-guard

### DIFF
--- a/contracts/cdp.pact
+++ b/contracts/cdp.pact
@@ -26,6 +26,15 @@
     true
   )
 
+  (defcap KDA_ABSORD:bool () 
+    @doc "Capability to absord KDA from liquidated vessels into the stability pool"
+    true
+  )
+
+  (defun register-kda-absord-guard:string ()
+    (cdp.stability-pool.register-kda-absord-guard (create-capability-guard (KDA_ABSORD)))
+  )
+
   (defun register-kusd-mint-guard:string ()
     (cdp.kusd-usd.register-cdp-mint-guard (create-capability-guard (KUSD_MINT)))
   )


### PR DESCRIPTION
Guard stability pool absorbing making sure only able to do so, 

The stability pool needs so absord the KDA from the vessel once liquidated. Its does this by increasing the amount in the DB table, this needs to be protected