### PR TITLE
feat(cdp) liquidate: dynamic ratio

### DIFF
--- a/contracts/cdp.pact
+++ b/contracts/cdp.pact
@@ -375,14 +375,14 @@
   (defun liquidation-reward:decimal (currentCR:decimal minCR:decimal)
     @doc "Calculate dynamic liquidation reward based on risk severity"
     ; Formula: (minCR - currentCR) / minCR
-    ; Example: minCR=110%, currentCR=108% → (110-108)/110 = 1.82%
-    (let ((severity (max 0.0 (/ (- minCR currentCR) minCR))))
+    ; Example: minCR=110%, currentCR=108% -> (110-108)/110 = 1.82%
+    (let ((severity (max 0.0 (/ (- minCR currentCR) minCR)))) ; Severity range: [0, 1]
     
     ;Final reward percentage
       ; Base: 0.5% minimum reward
       ;Risk premium: Additional 0-1.5% scaled by severity
       ; Formula: 0.005 + (severity × 0.015)
-    (+ 0.005 (* severity 0.015))))
+    (+ 0.005 (* severity 0.015)))) ; 0.005 + (1.0 × 0.015) = 0.02 = 2.0%
   
   ;; borrow only
   (defun update-debt-amount (account:string newDebtAmount:decimal)


### PR DESCRIPTION
**What it does**
Replaces static liquidation rewards with a dynamic, risk-based model that scales liquidators’ incentives according to how under-collateralized a vault is.

[maker-dao loss good read](https://medium.com/@whiterabbit_hq/black-thursday-for-makerdao-8-32-million-was-liquidated-for-0-dai-36b83cac56b6) **(even though we don't have auctions, the incentive increase will be great for maintaining liquidator interest)** 

Should be discusses with @ emily @ amir
---

### Key Changes

#### 1. Dynamic Reward Calculation

```pact
(defun liquidation-reward:decimal (currentCR:decimal minCR:decimal)
  @doc "0.5% base reward + up to 1.5% extra based on under-collateralization"
  (let ((severity (max 0.0 (/ (- minCR currentCR) minCR)))  ; [0,1]
    (+ 0.005 (* severity 0.015))))                         ; 0.5% → 2.0% max
```

* **Severity Formula**

  ```
  severity = max(0, (minCR – currentCR) / minCR)  
  ```

  * `minCR`: e.g. 110%
  * `currentCR`: actual vault CR
  * Ranges from 0.0 (at minCR) to 1.0 (no collateral)

* **Reward Calculation**

  ```
  reward_pct = 0.5% + (severity × 1.5%)  
  ```

  → naturally caps at 2.0% when `currentCR = 0%`

#### 2. Liquidation Logic Update

```pact
; Old static version
;(let ((calculatedRewardAmount
;        (* vesselCollateralAmount
;           (get-config "LIQUIDATION_REWARD"))))

; New dynamic version
(let ((rewardPct (liquidation-reward currentCR minCR))
      (calculatedRewardAmount (* vesselCollateralAmount rewardPct)))
  …)
```

#### 3. Full Integration in `liquidate-vault`

```pact
(defun liquidate-vault:string (liquidator targetVault)
  (with-capability (LIQUIDATE_VAULT liquidator targetVault)
    (with-read vessels targetVault { "collateralAmount":c, "debtAmount":d }
      (let ((currentCR (calculate-collateral-ratio c d))
            (minCR     (get-config "MIN_CR")))
        (let ((rewardPct (* c (liquidation-reward currentCR minCR))))
          …)))))
```

---

### Old vs New Rewards

| Scenario                       | Static | Dynamic | Protection                             |
| ------------------------------ | ------ | ------- | -------------------------------------- |
| **At minCR (110%)**            | 0.5%   | 0.5%    | Baseline unchanged                     |
| **Mild dip (108% CR)**         | 0.5%   | ≈0.52%  | Slightly higher for borderline         |
| **Significant drop (100% CR)** | 0.5%   | ≈0.64%  | Better incentives under stress         |
| **Crash (92% CR)**             | 0.5%   | ≈0.74%  | Strong crash response                  |
| **Full insolvency (0% CR)**    | 0.5%   | 2.0%    | Maximum protection (capped by formula) |

---

### What it covers

1. **Economic Incentives**
   During flash crashes (e.g. 35% in 24 h), a flat 0.5% reward often fails to offset gas spikes, slippage, and liquidators risk. Dynamic rewards automatically rise to 2.0% when needed, keeping liquidators motivated.

2. **Protocol Safety**
   We measure how much debt isn’t covered by collateral using **Risk Exposure**:

   ```math
   Risk Exposure = Total Debt × (1 − Collateral Ratio)
   ```

   * **Collateral Ratio (CR)** = collateral value ÷ debt
   * Example: If you owe 100 kUSD but your vault is only 92% collateralized,

     ```math
     Risk Exposure = 100 × (1 − 0.92) = 8 kUSD
     ```

     meaning $8 kUSD of unbacked debt. By boosting rewards as CR falls, liquidators clear risky vaults sooner, shrinking that exposure and safeguarding the system.

3. **kUSD Peg Protection**
   Ensures liquidations fire as soon as CR < minCR (110%), with at least

   ```pact
   0.5% + (minCR − currentCR)/minCR × 1.5%
   ```

   reward, so vaults never linger long enough to threaten the peg.

